### PR TITLE
fix: update entrypoint to fix password problems

### DIFF
--- a/entrypoints/all_in_one.sh
+++ b/entrypoints/all_in_one.sh
@@ -22,9 +22,15 @@ params="$(grep '^[0-9a-zA-Z]' ${SETTINGS_CONF} | awk -F'=' '{print $1}')"
 # Set random passwords.
 for param in ${params}; do
     if echo ${param} | grep -E '(_DB_PASSWORD|^MLMMJADMIN_API_TOKEN|^IREDAPD_SRS_SECRET|^ROUNDCUBE_DES_KEY|^MYSQL_ROOT_PASSWORD|^VMAIL_DB_ADMIN_PASSWORD)$' &>/dev/null; then
-        if grep "^${param}\$" ${SETTINGS_CONF} &>/dev/null; then
+        if grep "^${param}=." ${SETTINGS_CONF} &>/dev/null; then
             # Replace existing variable to avoid add duplicate line.
-            ${CMD_SED} "s#^\(${param}=\).*#\1$(${RANDOM_PASSWORD})#g" ${SETTINGS_CONF}
+            # ${CMD_SED} "s#^\(${param}=\).*#\1$(${RANDOM_PASSWORD})#g" ${SETTINGS_CONF}
+            # DO NOTHING.
+            :
+            # Because PH_VMAIL_DB_PASSWORD placeholder is used to replace the password in postfix configurations.
+            # The placeholder will no longer exist once PH_VMAIL_DB_PASSWORD is replaced with some password.
+            # So if the password is changed here, postfix configurations will not sync.
+            # Either do nothing or change the password filling method for postfix configuration.
         else
             echo "${param}=$(${RANDOM_PASSWORD})" >> ${SETTINGS_CONF}
         fi


### PR DESCRIPTION
Fix the regex for the detection of password existence and prevent the password replacement leading to the out of sync with postfix configurations.