### PR TITLE
fixed: corrected permissions for SSL private key

### DIFF
--- a/entrypoints/dovecot.sh
+++ b/entrypoints/dovecot.sh
@@ -47,10 +47,9 @@ if [[ ! -f ${SSL_CERT_FILE} ]] || [[ ! -f ${SSL_KEY_FILE} ]]; then
         -newkey rsa:${SSL_KEY_LENGTH} \
         -out ${SSL_CERT_FILE} \
         -keyout ${SSL_KEY_FILE} >/dev/null
-
-    cat ${SSL_CERT_FILE} ${SSL_KEY_FILE} > ${SSL_COMBINED_FILE}
 fi
-chmod 0644 ${SSL_CERT_FILE} ${SSL_KEY_FILE} ${SSL_COMBINED_FILE}
+chmod 0644 ${SSL_CERT_FILE} ${SSL_COMBINED_FILE}
+chmod 0640 ${SSL_KEY_FILE}
 
 # Create dh param.
 if [[ ! -f ${SSL_DHPARAM2048_FILE} ]]; then


### PR DESCRIPTION
The SSL private key is now set to not be world readable. 

In addition the `combined.pem` (aka `fullchain.pem`) was incorrectly including the private key. The `fullchain.pem` files should never include the private key. They contain only the certificate and the CA certificates necessary to validate the certificate. In most cases the CA certificates would be user supplied for CA(s) that are not included in the `ca-certificates` package. 

Signed-off-by: Gerard Hickey <hickey@kinetic-compute.com>