### PR TITLE
Fixed clamav log file so logrotation happens

### DIFF
--- a/config/etc/rsyslog.d/1-iredmail-clamav.conf
+++ b/config/etc/rsyslog.d/1-iredmail-clamav.conf
@@ -3,7 +3,7 @@
 # please do __NOT__ modify it manually.
 #
 
-if $syslogtag startswith 'clamd' then -/var/log/clamav/clamd.log
+if $syslogtag startswith 'clamd' then -/var/log/clamav/clamav.log
 & stop
 
 if $syslogtag startswith 'freshclam' then -/var/log/clamav/freshclam.log


### PR DESCRIPTION
/etc/logrotate.d/clamav-daemon is expecting to have the log file located
at /var/log/clamav/clamav.log. This changes rsyslog to send log events
to clamav.log instead of clamd.log so that logrotate will correctly
rotate files rather than move them and have rsyslog continue using
file handles that point to the first rotation of the log file.