### PR TITLE
Added makefile and made all containers buildable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 iredmail.conf
+iredmail-variables.env
 data

--- a/Dockerfiles/antispam
+++ b/Dockerfiles/antispam
@@ -6,6 +6,7 @@ FROM ubuntu:focal
 MAINTAINER Zhang Huangbin <zhb@iredmail.org>
 EXPOSE 10024 10026 9998 10027 3310
 
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends amavisd-new libcrypt-openssl-rsa-perl libmail-dkim-perl altermime arj nomarch cpio liblz4-tool lzop cabextract p7zip-full rpm libmail-spf-perl unrar-free pax libdbd-mysql-perl clamav-freshclam clamav-daemon spamassassin && \
     apt-get clean && apt-get autoclean && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfiles/dovecot
+++ b/Dockerfiles/dovecot
@@ -1,7 +1,7 @@
 FROM ubuntu:focal
 MAINTAINER Zhang Huangbin <zhb@iredmail.org>
 EXPOSE 110 995 143 993 4190 24 12340 24242 12346
-
+ENV DEBIAN_FRONTEND noninteractive
 ARG SCRIPTS_DIR=/docker/scripts
 
 RUN mkdir -p ${SCRIPTS_DIR}

--- a/Dockerfiles/iredapd
+++ b/Dockerfiles/iredapd
@@ -9,9 +9,11 @@ COPY ./scripts/add_user_iredapd.sh ${SCRIPTS_DIR}/
 RUN /bin/sh ${SCRIPTS_DIR}/add_user_iredapd.sh && \
     rm -rf ${SCRIPTS_DIR}
 
-RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends python3-sqlalchemy python3-dnspython python3-pymysql python3-ldap python3-psycopg2 python3-more-itertools && \
-    apt-get clean && apt-get autoclean && rm -rf /var/lib/apt/lists/* && \
-    wget -c https://github.com/iredmail/iRedAPD/archive/5.0.4.tar.gz && \
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends python3-sqlalchemy python3-dnspython python3-pymysql python3-ldap python3-psycopg2 python3-more-itertools python3-apt python3-setuptools python3-pip wget ca-certificates && \
+    apt-get clean && apt-get autoclean && rm -rf /var/lib/apt/lists/*
+
+RUN wget -c https://github.com/iredmail/iRedAPD/archive/5.0.4.tar.gz && \
     tar xzf 5.0.4.tar.gz -C /opt && \
     rm -f 5.0.4.tar.gz && \
     ln -sf /opt/iRedAPD-5.0.4 /opt/iredapd && \

--- a/Dockerfiles/mariadb
+++ b/Dockerfiles/mariadb
@@ -3,6 +3,7 @@ MAINTAINER Zhang Huangbin <zhb@iredmail.org>
 
 EXPOSE 3306
 
+ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends mariadb-server && \
     apt-get clean && apt-get autoclean && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfiles/postfix
+++ b/Dockerfiles/postfix
@@ -8,6 +8,8 @@ FROM ubuntu:focal
 MAINTAINER Zhang Huangbin <zhb@iredmail.org>
 EXPOSE 25 465 587 7790
 
+ENV DEBIAN_FRONTEND noninteractive
+
 ARG SCRIPTS_DIR=/docker/scripts
 RUN mkdir -p ${SCRIPTS_DIR}
 COPY ./scripts/add_user_mlmmj.sh ${SCRIPTS_DIR}/

--- a/Dockerfiles/sogo
+++ b/Dockerfiles/sogo
@@ -3,7 +3,7 @@
 # please do __NOT__ modify it manually.
 #
 
-FROM ubuntu:18.04
+FROM ubuntu:focal
 MAINTAINER Zhang Huangbin <zhb@iredmail.org>
 
 # SOGo uses port `20000` by default.
@@ -13,7 +13,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV LC_ALL C
 ENV APT_KEY_DONT_WARN_ON_DANGEROUS_USAGE yes
 
-ARG SOGO_MIRROR_SITE=https://packages.inverse.ca/SOGo/nightly/4/ubuntu/
+ARG SOGO_MIRROR_SITE=https://packages.inverse.ca/SOGo/nightly/5/ubuntu/
 ARG ENTRYPOINTS_DIR=/docker/entrypoints
 
 # Create temporary file /usr/share/doc/sogo/test.sh to avoid an error in the
@@ -32,7 +32,7 @@ RUN apt-get update && apt-get upgrade -y && apt-get install -y --no-install-reco
         's#http://security.ubuntu.com/ubuntu/#[trusted=yes] http://archive.ubuntu.com/ubuntu/#g' \
         /etc/apt/sources.list \
         && apt-key adv --keyserver keyserver.ubuntu.com --recv-key 0x810273C4 \
-	&& echo "deb ${SOGO_MIRROR_SITE} bionic bionic" > /etc/apt/sources.list.d/sogo-nightly.list \
+	&& echo "deb ${SOGO_MIRROR_SITE} focal focal" > /etc/apt/sources.list.d/sogo-nightly.list \
 	&& apt-get update \
     && mkdir -p /usr/share/doc/sogo/ \
     && touch /usr/share/doc/sogo/test.sh \
@@ -45,9 +45,8 @@ COPY ./entrypoints/functions.sh ${ENTRYPOINTS_DIR}/
 COPY ./settings.conf ${ENTRYPOINTS_DIR}/
 
 # Copy config files.
-COPY sogo/. /
-COPY config/etc/supervisord.conf /etc/supervisor/
-COPY config/etc/supervisor.d /etc/
+# COPY config/sogo/. /
+COPY config/etc/supervisor /etc/
 COPY ./entrypoints/sogo.sh /entrypoint.sh
 
 ENTRYPOINT ["/bin/bash", "/entrypoint.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+ROOT := $(shell realpath .)
+BUILD ?= build
+DOCKERFILES_PATH := $(ROOT)/Dockerfiles
+DOCKERFILE_ALL := $(DOCKERFILES_PATH)/Dockerfile
+
+DOCKER_CMD ?= $(shell (type podman > /dev/null 2>&1 && echo "podman") || (type docker > /dev/null 2>&1 && echo "docker") || echo podman)
+DOCKER_REPO ?= localhost:5000
+DOCKER_IMAGE_TAG ?= latest
+DOCKER_IMAGE_GROUP ?= iredmail
+DOCKER_IMAGE_NAME ?= $(DOCKER_IMAGE_GROUP)/mariadb:$(DOCKER_IMAGE_TAG)
+DOCKER_IMAGES_LIST = antispam dovecot iredapd mariadb postfix sogo
+
+.PHONY: build send clean build-all
+build-all:
+	for i in $(DOCKER_IMAGES_LIST); do \
+		echo Building the $$i container ; \
+        $(DOCKER_CMD) build -t $(DOCKER_IMAGE_GROUP)/$$i:$(DOCKER_IMAGE_TAG) -f $(DOCKERFILES_PATH)/$$i . ; \
+    done
+
+clean:
+	$(RM) -r $(BUILD)
+	$(DOCKER_CMD) rmi $(shell $(DOCKER_CMD) images --format '{{.Repository}}:{{.Tag}}' | grep $(DOCKER_IMAGE_GROUP))
+
+build: $(DOCKERFILE_ALL)
+	$(DOCKER_CMD) build -t $(DOCKER_IMAGE_NAME) -f $(DOCKERFILE_ALL) .
+
+send: build
+	$(DOCKER_CMD) tag $(DOCKER_IMAGE_NAME) $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)
+	$(DOCKER_CMD) push $(DOCKER_REPO)/$(DOCKER_IMAGE_NAME)

--- a/README.md
+++ b/README.md
@@ -127,6 +127,60 @@ docker run \
     iredmail/mariadb:stable
 ```
 
+One of the easiest ways to run docker containers is through docker-compose
+```
+version: '3.5'
+
+services:
+#
+# IREDMAIL
+#
+  iredmail: 
+    image: iredmail/mariadb:nightly
+    restart: unless-stopped
+    container_name: iredmail
+    hostname: mail.mydomain.com
+    env_file:
+      - iredmail-docker.conf
+    volumes:
+      - iredmail-backup-mysql:/var/vmail/backup/mysql
+      - iredmail-mailboxes:/var/vmail/vmail1
+      - iredmail-mlmmj:/var/vmail/mlmmj
+      - iredmail-mlmmj-archive:/var/vmail/mlmmj-archive
+      - iredmail-imapsieve-copy:/var/vmail/imapsieve_copy
+      - iredmail-custom:/opt/iredmail/custom
+      - iredmail-ssl:/opt/iredmail/ssl
+      - iredmail-mysql:/var/lib/mysql
+      - iredmail-clamav:/var/lib/clamav
+      - iredmail-sa-rules:/var/lib/spamassassin
+      - iredmail-postfix-queue:/var/spool/postfix
+    ports: 
+      - 80:80
+      - 443:443
+      - 25:25
+      - 587:587
+      - 465:465
+      - 110:110
+      - 143:143
+      - 993:993
+      - 995:995
+#
+# VOLUMES
+#
+volumes:
+  iredmail-backup-mysql:
+  iredmail-mailboxes:
+  iredmail-mlmmj:
+  iredmail-mlmmj-archive:
+  iredmail-imapsieve-copy:
+  iredmail-custom:
+  iredmail-ssl:
+  iredmail-mysql:
+  iredmail-clamav:
+  iredmail-sa-rules:
+  iredmail-postfix-queue:
+  ```
+
 # Overview
 
 Only one config file `iredmail-docker.conf` on Docker host.

--- a/docker-compose-multiple-containers.yml
+++ b/docker-compose-multiple-containers.yml
@@ -1,0 +1,92 @@
+version: '3.5'
+
+services:
+#
+# IREDMAIL
+#
+  antispam:
+    image: iredmail/antispam:latest
+    restart: unless-stopped
+    container_name: antispam
+    env_file:
+      - iredmail-docker.conf
+    volumes:
+      - iredmail-clamav:/var/lib/clamav
+      - iredmail-sa-rules:/var/lib/spamassassin
+  dovecot:
+    image: iredmail/dovecot:latest
+    restart: unless-stopped
+    container_name: dovecot
+    env_file:
+      - iredmail-docker.conf
+    ports:
+      - 465:465
+      - 110:110
+      - 143:143
+      - 993:993
+      - 995:995
+  iredapd:
+    image: iredmail/iredapd:latest
+    restart: unless-stopped
+    container_name: iredapd
+    env_file:
+      - iredmail-docker.conf
+    volumes:
+      - iredmail-mailboxes:/var/vmail/vmail1
+      - iredmail-mlmmj:/var/vmail/mlmmj
+      - iredmail-mlmmj-archive:/var/vmail/mlmmj-archive
+      - iredmail-imapsieve-copy:/var/vmail/imapsieve_copy
+      - iredmail-custom:/opt/iredmail/custom
+      - iredmail-ssl:/opt/iredmail/ssl
+  mariadb:
+    image: iredmail/mariadb:latest
+    restart: unless-stopped
+    container_name: mariadb
+    env_file:
+      - iredmail-docker.conf
+    volumes:
+      - iredmail-backup-mysql:/var/vmail/backup/mysql
+      - iredmail-mysql:/var/lib/mysql
+  postfix:
+    image: iredmail/postfix:latest
+    restart: unless-stopped
+    container_name: postfix
+    env_file:
+      - iredmail-docker.conf
+    ports:
+      - 25:25
+      - 587:587
+      - 465:465
+    volumes:
+      - iredmail-mailboxes:/var/vmail/vmail1
+      - iredmail-mlmmj:/var/vmail/mlmmj
+      - iredmail-mlmmj-archive:/var/vmail/mlmmj-archive
+      - iredmail-imapsieve-copy:/var/vmail/imapsieve_copy
+      - iredmail-custom:/opt/iredmail/custom
+      - iredmail-ssl:/opt/iredmail/ssl
+  sogo:
+    image: iredmail/sogo:latest
+    env_file:
+      - iredmail-docker.conf
+    volumes:
+      - iredmail-mailboxes:/var/vmail/vmail1
+      - iredmail-mlmmj:/var/vmail/mlmmj
+      - iredmail-mlmmj-archive:/var/vmail/mlmmj-archive
+      - iredmail-imapsieve-copy:/var/vmail/imapsieve_copy
+      - iredmail-custom:/opt/iredmail/custom
+      - iredmail-ssl:/opt/iredmail/ssl
+#
+# VOLUMES
+#
+volumes:
+  iredmail-backup-mysql:
+  iredmail-mailboxes:
+  iredmail-mlmmj:
+  iredmail-mlmmj-archive:
+  iredmail-imapsieve-copy:
+  iredmail-custom:
+  iredmail-ssl:
+  iredmail-mysql:
+  iredmail-clamav:
+  iredmail-sa-rules:
+  iredmail-postfix-queue:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,50 @@
+version: '3.5'
+
+services:
+#
+# IREDMAIL
+#
+  iredmail: 
+    image: iredmail/mariadb:nightly
+    restart: unless-stopped
+    container_name: iredmail
+    hostname: mail.mydomain.com
+    env_file:
+      - iredmail-docker.conf
+    volumes:
+      - iredmail-backup-mysql:/var/vmail/backup/mysql
+      - iredmail-mailboxes:/var/vmail/vmail1
+      - iredmail-mlmmj:/var/vmail/mlmmj
+      - iredmail-mlmmj-archive:/var/vmail/mlmmj-archive
+      - iredmail-imapsieve-copy:/var/vmail/imapsieve_copy
+      - iredmail-custom:/opt/iredmail/custom
+      - iredmail-ssl:/opt/iredmail/ssl
+      - iredmail-mysql:/var/lib/mysql
+      - iredmail-clamav:/var/lib/clamav
+      - iredmail-sa-rules:/var/lib/spamassassin
+      - iredmail-postfix-queue:/var/spool/postfix
+    ports:
+      - 80:80
+      - 443:443
+      - 25:25
+      - 587:587
+      - 465:465
+      - 110:110
+      - 143:143
+      - 993:993
+      - 995:995
+#
+# VOLUMES
+#
+volumes:
+  iredmail-backup-mysql:
+  iredmail-mailboxes:
+  iredmail-mlmmj:
+  iredmail-mlmmj-archive:
+  iredmail-imapsieve-copy:
+  iredmail-custom:
+  iredmail-ssl:
+  iredmail-mysql:
+  iredmail-clamav:
+  iredmail-sa-rules:
+  iredmail-postfix-queue:


### PR DESCRIPTION
I am interested in adding support for SOGo and want to gauge how well PRs are received on this project.  I have made some very basic build files with the included Makefile that allows all containers in the project to be built.  It will also build the all in one container.  In the future I would like to see the mono container removed and the separate containers to become the standard since this will allow the application to be scaled.  I have also added docker-compose files that make deploying to a docker engine server much easier.

I have also updated the individual service containers so they build, but doubt they are anywhere near workable.  The only reason I am opening a PR at this point is the state is better than when I found it (following my do no harm mantra) and I want to know if it is even worth making the contribution.  My proposed changes will be rather in depth and take me a decent amount of time / effort.

Let me know if you have any concerns with theses additions.  If you are interested I will start working on integrating SOGo into the all in one container, then I will work on getting the multiple container setup working.